### PR TITLE
Compatibilty fixes for Laravel 11

### DIFF
--- a/src/NestedForm.php
+++ b/src/NestedForm.php
@@ -2,7 +2,7 @@
 
 namespace Handleglobal\NestedForm;
 
-use function GuzzleHttp\json_encode;
+use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 use Laravel\Nova\Contracts\RelatableField;
@@ -21,8 +21,8 @@ use Laravel\Nova\Http\Requests\DetachResourceRequest;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Http\Requests\UpdateResourceRequest;
 use Laravel\Nova\Nova;
-use Illuminate\Contracts\Validation\Rule;
 use Laravel\Nova\Panel;
+use Symfony\Component\HttpFoundation\FileBag;
 
 class NestedForm extends Field implements RelatableField
 {
@@ -530,7 +530,9 @@ class NestedForm extends Field implements RelatableField
             return $value === self::ID ? $model->getKey() : $value;
         })->toArray()));
 
-        $createRequest->files = collect($request->file($requestAttribute . '.' . $index));
+        if ($request->hasFile($requestAttribute . '.' . $index)) {
+            $createRequest->files = new FileBag($request->file($requestAttribute . '.' . $index));
+        }
 
         return $createRequest;
     }

--- a/src/NestedForm.php
+++ b/src/NestedForm.php
@@ -2,7 +2,7 @@
 
 namespace Handleglobal\NestedForm;
 
-use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 use Laravel\Nova\Contracts\RelatableField;
@@ -320,7 +320,7 @@ class NestedForm extends Field implements RelatableField
      */
     public function rules($rules)
     {
-        parent::rules(($rules instanceof Rule || is_string($rules)) ? func_get_args() : $rules);
+        parent::rules(($rules instanceof ValidationRule || is_string($rules)) ? func_get_args() : $rules);
 
         return $this->returnContext;
     }

--- a/src/NestedFormChild.php
+++ b/src/NestedFormChild.php
@@ -2,9 +2,6 @@
 
 namespace Handleglobal\NestedForm;
 
-use Illuminate\Database\Eloquent\Model;
-use Laravel\Nova\Fields\ID;
-
 class NestedFormChild extends NestedFormSchema
 {
 
@@ -30,7 +27,7 @@ class NestedFormChild extends NestedFormSchema
      *
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_merge(parent::jsonSerialize(), [
             'resourceId' => $this->model->getKey(),

--- a/src/NestedFormSchema.php
+++ b/src/NestedFormSchema.php
@@ -12,7 +12,6 @@ use Laravel\Nova\Fields\File;
 use Laravel\Nova\Fields\MorphTo;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
-use Laravel\Nova\Resource;
 use ReflectionMethod;
 
 class NestedFormSchema implements JsonSerializable
@@ -49,6 +48,11 @@ class NestedFormSchema implements JsonSerializable
      * @var string
      */
     protected static $filterMethod = 'creationFields';
+
+    /**
+     * Current request.
+     */
+    protected NovaRequest $request;
 
     /**
      * Create a new NestedFormSchema instance.
@@ -235,7 +239,7 @@ class NestedFormSchema implements JsonSerializable
      *
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'fields' => $this->fields,


### PR DESCRIPTION
Because of changes to Symfony's Request I've had to wrap the files in a FileBag as the following exception would be thrown otherwise:

```Cannot assign Illuminate\Support\Collection to property Symfony\Component\HttpFoundation\Request::$files of type Symfony\Component\HttpFoundation\FileBag```